### PR TITLE
Update Currency Controller

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -7,9 +7,10 @@ function CurrencyController(options) {
   var refresh = options.currencyRefresh || CurrencyController.DEFAULT_CURRENCY_DELAY;
   this.currencyDelay = refresh * 60000;
   this.exchange_rates = {
-    dash_usd: 0.00,
-    btc_usd: 0.00,
-    btc_dash: 0.00
+    pac_price: 0.00,
+    btc_price: 0.00,
+    btc_pac: 0.00,
+    currency: 'USD'
   };
   this.timestamp = Date.now();
 }
@@ -19,21 +20,51 @@ CurrencyController.DEFAULT_CURRENCY_DELAY = 10;
 CurrencyController.prototype.index = function(req, res) {
   var self = this;
   var currentTime = Date.now();
-  if (self.exchange_rates.dash_usd === 0.00 || currentTime >= (self.timestamp + self.currencyDelay)) {
+  req.params.currency = req.params.currency || 'USD';
+  if (self.exchange_rates.currency !== req.params.currency || currentTime >= (self.timestamp + self.currencyDelay)) {
+    self.exchange_rates.currency = req.params.currency;
     self.timestamp = currentTime;
-    request('https://www.dashcentral.org/api/v1/public', function(err, response, body) {
+    var exchange_api_url = 'https://api.coinmarketcap.com/v1';
+    var exchange_api_endpoint = '/ticker/paccoin/';
+    var bitcoinavg_api_url = 'https://apiv2.bitcoinaverage.com';
+    var bitcoinaverage_api_endpoint = '/convert/global?from=BTC&to='+self.exchange_rates.currency+'&amount=1';
+    
+    request(exchange_api_url+exchange_api_endpoint, function(err, response, body) {
       if (err) {
         self.node.log.error(err);
       }
       if (!err && response.statusCode === 200) {
         var response = JSON.parse(body);
-        self.exchange_rates = response.exchange_rates;
-        self.exchange_rates.bitstamp = response.exchange_rates.dash_usd; // backwards compatibility
+        self.exchange_rates.btc_pac = response[0].price_btc;
+        request(bitcoinavg_api_url+bitcoinaverage_api_endpoint, function(err, response, body) {
+          if (err) {
+            self.node.log.error(err);
+          }
+          if (!err && response.statusCode === 200) {
+            var response = JSON.parse(body);
+            self.exchange_rates.btc_price = response.price;
+            self.exchange_rates.pac_price = response.price * self.exchange_rates.btc_pac;
+            res.jsonp({
+              status: 200,
+              data: self.exchange_rates
+            });
+          } else {
+            self.exchange_rates = {pac_price: 0.00, btc_price: 0.00, btc_pac: 0.00};
+            res.jsonp({
+              status: response.statusCode,
+              data: self.exchange_rates
+            });
+          }
+        });
+      } else {
+        self.exchange_rates = {pac_price: 0.00, btc_price: 0.00, btc_pac: 0.00};
+        response = response || {};
+        response.statusCode = response.statusCode || 400;
+        res.jsonp({
+          status: response.statusCode,
+          data: self.exchange_rates
+        });
       }
-      res.jsonp({
-        status: 200,
-        data: self.exchange_rates
-      });
     });
   } else {
     res.jsonp({
@@ -41,7 +72,6 @@ CurrencyController.prototype.index = function(req, res) {
       data: self.exchange_rates
     });
   }
-
 };
 
 module.exports = CurrencyController;

--- a/lib/index.js
+++ b/lib/index.js
@@ -261,6 +261,7 @@ InsightAPI.prototype.setupRoutes = function(app) {
     currencyRefresh: this.currencyRefresh
   });
   app.get('/currency', currency.index.bind(currency));
+  app.get('/currency/:currency', currency.index.bind(currency));
 
   // Not Found
   app.use(function(req, res) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-pac-api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insight-pac-api",
   "description": "A $PAC blockchain REST and web socket API service for Bitcore Node.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": "git://github.com/PACCommunity/insight-pac-api.git",
   "contributors": [
     {

--- a/test/currency.js
+++ b/test/currency.js
@@ -18,9 +18,10 @@ describe('Currency', function() {
       registered_masternodes_verified: 770
     },
     exchange_rates: {
-      dash_usd: 9.4858840414,
-      btc_usd: 682.93,
-      btc_dash: 0.01388998
+      pac_price: 9.4858840414,
+      btc_price: 682.93,
+      btc_pac: 0.01388998,
+      currency: 'USD'
     }
   };
 
@@ -30,8 +31,8 @@ describe('Currency', function() {
     var res = {
       jsonp: function(response) {
         response.status.should.equal(200);
-        should.exist(response.data.dash_usd);
-        (typeof response.data.dash_usd).should.equal('number');
+        should.exist(response.data.pac_price);
+        (typeof response.data.pac_price).should.equal('number');
         done();
       }
     };
@@ -49,17 +50,22 @@ describe('Currency', function() {
     };
     var currency = new TestCurrencyController({node: node});
     currency.exchange_rates = {
-      dash_usd: 9.4858840414,
-      btc_usd: 682.93,
-      btc_dash: 0.01388998
+      pac_price: 9.4858840414,
+      btc_price: 682.93,
+      btc_pac: 0.01388998,
+      currency: 'USD'
     };
-    currency.timestamp = Date.now() - 61000 * CurrencyController.DEFAULT_CURRENCY_DELAY;
-    var req = {};
+    currency.timestamp = Date.now() - 51000 * CurrencyController.DEFAULT_CURRENCY_DELAY;
+    var req = {
+      params: {
+        currency: 'USD'    
+      }
+    };
     var res = {
       jsonp: function(response) {
         response.status.should.equal(200);
-        should.exist(response.data.dash_usd);
-        response.data.dash_usd.should.equal(9.4858840414);
+        should.exist(response.data.pac_price);
+        response.data.pac_price.should.equal(9.4858840414);
         done();
       }
     };
@@ -77,17 +83,22 @@ describe('Currency', function() {
     };
     var currency = new TestCurrencyController({node: node});
     currency.exchange_rates = {
-      dash_usd: 9.4858840414,
-      btc_usd: 682.93,
-      btc_dash: 0.01388998
+      pac_price: 9.4858840414,
+      btc_price: 682.93,
+      btc_pac: 0.01388998,
+      currency: 'USD'
     };
     currency.timestamp = Date.now() - 65000 * CurrencyController.DEFAULT_CURRENCY_DELAY;
-    var req = {};
+    var req = {
+      params: {
+        currency: 'USSD'    
+      }
+    };
     var res = {
       jsonp: function(response) {
-        response.status.should.equal(200);
+        response.status.should.equal(400);
         should.exist(response.data);
-        response.data.dash_usd.should.equal(9.4858840414);
+        response.data.pac_price.should.equal(0);
         node.log.error.callCount.should.equal(1);
         done();
       }
@@ -107,17 +118,22 @@ describe('Currency', function() {
     };
     var currency = new TestCurrencyController({node: node});
     currency.exchange_rates = {
-      dash_usd: 9.4858840414,
-      btc_usd: 682.93,
-      btc_dash: 0.01388998
+      pac_price: 9.4858840414,
+      btc_price: 682.93,
+      btc_pac: 0.01388998,
+      currency: 'USD'
     };
     currency.timestamp = Date.now();
-    var req = {};
+    var req = {
+      params: {
+        currency: 'USD'    
+      }
+    };
     var res = {
       jsonp: function(response) {
         response.status.should.equal(200);
-        should.exist(response.data.dash_usd);
-        response.data.dash_usd.should.equal(9.4858840414);
+        should.exist(response.data.pac_price);
+        response.data.pac_price.should.equal(9.4858840414);
         request.callCount.should.equal(0);
         done();
       }


### PR DESCRIPTION
This fixes the currency controller to get the correct $PAC price.

Added a new endpoint to get the $PAC price in a specific currency: 

`/currency/:currency` where `:currency` currency can be a currency ticker.

For example: `/currency/USD`, `/currency/JPY` or `/currency/MXN`